### PR TITLE
Update XML parsing functions

### DIFF
--- a/lastexport.py
+++ b/lastexport.py
@@ -124,12 +124,12 @@ def get_pageinfo(response, tracktype='recenttracks'):
 def get_tracklist(response):
     """Read XML page and get a list of tracks and their info."""
     xmlpage = ET.fromstring(response)
-    tracklist = xmlpage.getiterator('track')
+    tracklist = xmlpage.iter('track')
     return tracklist
 
 def parse_track(trackelement):
     """Extract info from every track entry and output to list."""
-    if trackelement.find('artist').getchildren():
+    for elem in trackelement.find('artist'):
         #artist info is nested in loved/banned tracks xml
         artistname = trackelement.find('artist').find('name').text
         artistmbid = trackelement.find('artist').find('mbid').text


### PR DESCRIPTION
Fixing #24 

Updating code to avoid these errors:
```AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getchildren'```
```AttributeError: 'xml.etree.ElementTree.Element' object has no attribute 'getiterator'```


Results in valid results still, e.g.,

```1636525014	(Baby I Don’t Know) What You Want	Jacques Greene	ANTH01			4407e4ca-1877-4f0c-a4d9-70c6373e48f6```